### PR TITLE
Add custom webpack config for Blockbook

### DIFF
--- a/.blockbook/webpack.config.js
+++ b/.blockbook/webpack.config.js
@@ -1,0 +1,10 @@
+const path = require('path');
+module.exports = (config) => {
+	return {
+		...config,
+		devServer: {
+			...config.devServer,
+			static: path.resolve(process.cwd(), '../../..'),
+		},
+	};
+};


### PR DESCRIPTION
Adds the entire WP directory as static files. We're going to have to see if this leads to any performance issues (seems okay so far), but this is necessary because webpack builds paths to fonts at `/wp-content/themes/wp-next-theme/dist/fonts/[name]`, so in order to see the fonts in Blockbook, that path has to work.